### PR TITLE
Fix CI: use testing API key and optimize integration test runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,7 +105,7 @@ jobs:
           fi
 
   integration-tests:
-    name: All Tests with Integration (Real LLM)
+    name: Integration Tests (Real LLM)
     runs-on: ubuntu-latest
     needs: [check-changes]
     # Only run integration tests when:
@@ -128,29 +128,26 @@ jobs:
           pip install -e ".[dev]"
           pip install pytest-timeout
 
-      - name: Run ALL tests (unit + integration) for combined coverage
+      - name: Run integration tests only
         env:
           OPENROUTER_API_KEY_FOR_TESTING: ${{ secrets.OPENROUTER_API_KEY_FOR_TESTING }}
         run: |
           # Only run if the secret is available
           if [ -n "$OPENROUTER_API_KEY_FOR_TESTING" ]; then
-            echo "Running ALL tests (unit + integration) with OpenRouter..."
-            # Run all tests together to get combined coverage
-            pytest tests/ -v --timeout=180 --cov=src --cov-report=xml:coverage-combined.xml --cov-report=term-missing
+            echo "Running integration tests with OpenRouter..."
+            pytest tests/ -v -m integration --timeout=180 --cov=src --cov-report=xml:coverage-integration.xml --cov-report=term-missing
           else
             echo "OPENROUTER_API_KEY_FOR_TESTING not set, skipping integration tests"
           fi
 
-      - name: Upload combined coverage to Codecov
-        # Always upload coverage, even if some tests fail
-        # This ensures partial coverage is still counted
+      - name: Upload integration coverage to Codecov
         if: always()
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage-combined.xml
-          flags: combined
-          name: codecov-combined
+          files: ./coverage-integration.xml
+          flags: integration
+          name: codecov-integration
           fail_ci_if_error: false
 
   all-tests:

--- a/codecov.yml
+++ b/codecov.yml
@@ -47,9 +47,9 @@ flags:
     paths:
       - src/
     carryforward: true
-  combined:
+  integration:
     paths:
       - src/
     carryforward: true
-    # Combined flag has full coverage from all tests run together
-    # This is the authoritative coverage number
+    # Integration tests run less frequently (only when related files change)
+    # Carryforward ensures previous coverage is used when skipped

--- a/src/scripts/process_feedback.py
+++ b/src/scripts/process_feedback.py
@@ -47,12 +47,12 @@ async def process_feedback_file(
     from src.utils.github_client import GitHubClient
     from src.utils.openrouter_llm import create_openrouter_llm
 
-    # Get API keys from environment
-    openrouter_key = os.getenv("OPENROUTER_API_KEY")
+    # Get API keys from environment (prefer testing key for CI/tests)
+    openrouter_key = os.getenv("OPENROUTER_API_KEY_FOR_TESTING") or os.getenv("OPENROUTER_API_KEY")
     github_token = os.getenv("GITHUB_TOKEN")
 
     if not openrouter_key:
-        logger.error("OPENROUTER_API_KEY not set")
+        logger.error("OPENROUTER_API_KEY or OPENROUTER_API_KEY_FOR_TESTING not set")
         sys.exit(1)
 
     # Get model configuration from environment


### PR DESCRIPTION
## Summary
- Fix `process_feedback.py` to check `OPENROUTER_API_KEY_FOR_TESTING` first, then fall back to `OPENROUTER_API_KEY`
- Keep unit and integration tests separate with codecov flag carryforward for proper coverage merging
- Integration tests only run when related files change (agents, validation, openrouter code)

## Changes
- `src/scripts/process_feedback.py`: Prefer testing API key in CI environment
- `.github/workflows/test.yml`: Maintain separate test jobs with proper codecov flags

## Test plan
- [x] Unit tests pass
- [x] Integration tests pass when triggered
- [x] Codecov receives coverage reports correctly