### PR TITLE
Update default HED schema version to 8.4.0

### DIFF
--- a/src/agents/workflow.py
+++ b/src/agents/workflow.py
@@ -382,7 +382,7 @@ class HedAnnotationWorkflow:
     async def run(
         self,
         input_description: str,
-        schema_version: str = "8.3.0",
+        schema_version: str = "8.4.0",
         max_validation_attempts: int = 5,
         max_total_iterations: int = 10,
         run_assessment: bool = False,

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -23,7 +23,7 @@ class AnnotationRequest(BaseModel):
         examples=["A red circle appears on the left side of the screen"],
     )
     schema_version: str = Field(
-        default="8.3.0",
+        default="8.4.0",
         description="HED schema version",
         examples=["8.3.0", "8.4.0"],
     )
@@ -103,7 +103,7 @@ class ValidationRequest(BaseModel):
         min_length=1,
     )
     schema_version: str = Field(
-        default="8.3.0",
+        default="8.4.0",
         description="HED schema version",
     )
 

--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -151,7 +151,7 @@ class HEDitClient:
     def annotate(
         self,
         description: str,
-        schema_version: str = "8.3.0",
+        schema_version: str = "8.4.0",
         max_validation_attempts: int = 5,
         run_assessment: bool = False,
     ) -> dict[str, Any]:
@@ -182,7 +182,7 @@ class HEDitClient:
     def annotate_stream(
         self,
         description: str,
-        schema_version: str = "8.3.0",
+        schema_version: str = "8.4.0",
         max_validation_attempts: int = 5,
         run_assessment: bool = False,
     ) -> Generator[tuple[str, dict[str, Any]], None, None]:
@@ -360,7 +360,7 @@ class HEDitClient:
     def validate(
         self,
         hed_string: str,
-        schema_version: str = "8.3.0",
+        schema_version: str = "8.4.0",
     ) -> dict[str, Any]:
         """Validate HED string.
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -84,7 +84,7 @@ SchemaVersionOption = Annotated[
     typer.Option(
         "--schema",
         "-s",
-        help="HED schema version (e.g., 8.3.0, 8.4.0)",
+        help="HED schema version (default: 8.4.0)",
     ),
 ]
 

--- a/src/utils/schema_loader.py
+++ b/src/utils/schema_loader.py
@@ -33,7 +33,7 @@ class HedSchemaLoader:
 
     def load_schema(
         self,
-        schema_spec: str = "8.3.0",
+        schema_spec: str = "8.4.0",
         library_name: str | None = None,
     ) -> HedSchema:
         """Load a HED schema from version string or file path.

--- a/src/validation/hed_validator.py
+++ b/src/validation/hed_validator.py
@@ -47,7 +47,7 @@ def is_js_validator_available(validator_path: Path | str | None = None) -> bool:
 
 
 def get_validator(
-    schema_version: str = "8.3.0",
+    schema_version: str = "8.4.0",
     prefer_js: bool = True,
     require_js: bool = False,
     validator_path: Path | str | None = None,
@@ -205,7 +205,7 @@ class HedJavaScriptValidator:
     def __init__(
         self,
         validator_path: Path,
-        schema_version: str = "8.3.0",
+        schema_version: str = "8.4.0",
     ) -> None:
         """Initialize JavaScript validator.
 


### PR DESCRIPTION
## Summary
- Update all default `schema_version` parameters from `8.3.0` to `8.4.0` across workflow, API models, validators, schema loader, and CLI
- Aligns with OSA which already uses 8.4.0
- Tests that explicitly pass `8.3.0` are unchanged (testing specific schema behavior)

## Test plan
- [x] All 377 unit tests pass
- [ ] Verify annotations generated with 8.4.0 schema are valid

Closes #97