### PR TITLE
perf: fast keyword extraction + disable reasoning on lightweight LLMs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hedit"
-version = "0.7.10a1"
+version = "0.7.10a2"
 description = "Multi-agent system for HED annotation generation and validation"
 readme = "PKG_README.md"
 requires-python = ">=3.12"

--- a/src/agents/workflow.py
+++ b/src/agents/workflow.py
@@ -46,6 +46,7 @@ class HedAnnotationWorkflow:
         evaluation_llm: BaseChatModel | None = None,
         assessment_llm: BaseChatModel | None = None,
         feedback_llm: BaseChatModel | None = None,
+        keyword_llm: BaseChatModel | None = None,
         schema_dir: Path | str | None = None,
         validator_path: Path | None = None,
         use_js_validator: bool = True,
@@ -59,6 +60,13 @@ class HedAnnotationWorkflow:
             evaluation_llm: Language model for evaluation agent (defaults to llm)
             assessment_llm: Language model for assessment agent (defaults to llm)
             feedback_llm: Language model for feedback summarization (defaults to llm)
+            keyword_llm: Lightweight LLM for keyword extraction inside
+                ``_semantic_preprocess_node``. Defaults to ``llm`` (the
+                annotation LLM, typically a fast model like claude-haiku
+                with reasoning disabled). Previously this task piggy-backed
+                on ``feedback_llm`` which in prod is wired to the heavier
+                evaluation model — a five-keyword extraction does not
+                need a 35B-parameter model with extended reasoning.
             schema_dir: Directory containing JSON schemas
             validator_path: Path to hed-javascript for validation
             use_js_validator: Whether to use JavaScript validator
@@ -82,9 +90,12 @@ class HedAnnotationWorkflow:
         eval_llm = evaluation_llm or llm
         assess_llm = assessment_llm or llm
         feed_llm = feedback_llm or llm
+        kw_llm = keyword_llm or llm
 
-        # Store feedback LLM for keyword extraction (cheap/fast model)
-        self.feedback_llm = feed_llm
+        # Keyword extraction uses a dedicated lightweight model
+        # (defaults to the annotation LLM, which is typically fast +
+        # reasoning-disabled for this short structured task).
+        self.keyword_llm = kw_llm
 
         # Initialize agents with JSON schema support and per-agent LLMs
         self.annotation_agent = AnnotationAgent(llm, schema_dir=self.schema_dir)
@@ -196,7 +207,7 @@ class HedAnnotationWorkflow:
         )
 
         try:
-            response = await self.feedback_llm.ainvoke(
+            response = await self.keyword_llm.ainvoke(
                 [
                     SystemMessage(content=system_prompt),
                     HumanMessage(content=f"Description: {description}"),

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -159,7 +159,10 @@ def create_openrouter_workflow(
 
     actual_eval_provider = eval_provider or default_eval_provider or None
 
-    # Create LLMs
+    # Create LLMs.
+    # The annotation LLM keeps reasoning enabled — that's the model
+    # doing the actual HED tag synthesis where extended thinking
+    # measurably improves first-attempt quality.
     annotation_llm = create_openrouter_llm(
         model=actual_annotation_model,
         api_key=api_key,
@@ -167,12 +170,16 @@ def create_openrouter_workflow(
         provider=actual_annotation_provider,
         user_id=actual_user_id,
     )
+    # Evaluation / assessment / feedback / keyword extraction are short
+    # structured tasks; reasoning adds 5-10 s per call without
+    # measurable quality benefit. See #150.
     evaluation_llm = create_openrouter_llm(
         model=actual_eval_model,
         api_key=api_key,
         temperature=actual_temperature,
         provider=actual_eval_provider,
         user_id=actual_user_id,
+        disable_reasoning=True,
     )
     assessment_llm = create_openrouter_llm(
         model=actual_eval_model,
@@ -180,6 +187,7 @@ def create_openrouter_workflow(
         temperature=actual_temperature,
         provider=actual_eval_provider,
         user_id=actual_user_id,
+        disable_reasoning=True,
     )
     feedback_llm = create_openrouter_llm(
         model=actual_eval_model,
@@ -187,6 +195,20 @@ def create_openrouter_workflow(
         temperature=actual_temperature,
         provider=actual_eval_provider,
         user_id=actual_user_id,
+        disable_reasoning=True,
+    )
+    # Keyword extraction (#148): use the fast annotation model with
+    # reasoning explicitly disabled and a small token cap. The
+    # task is "list 5-10 keywords"; the heavier eval model used here
+    # previously cost ~10 s per call.
+    keyword_llm = create_openrouter_llm(
+        model=actual_annotation_model,
+        api_key=api_key,
+        temperature=actual_temperature,
+        provider=actual_annotation_provider,
+        user_id=actual_user_id,
+        max_tokens=200,
+        disable_reasoning=True,
     )
 
     # Create and return workflow
@@ -199,6 +221,7 @@ def create_openrouter_workflow(
         evaluation_llm=evaluation_llm,
         assessment_llm=assessment_llm,
         feedback_llm=feedback_llm,
+        keyword_llm=keyword_llm,
         schema_dir=Path(schema_dir) if schema_dir else None,
         validator_path=Path(validator_path) if validator_path else None,
         use_js_validator=actual_use_js,

--- a/src/cli/local_executor.py
+++ b/src/cli/local_executor.py
@@ -176,7 +176,7 @@ class LocalExecutionBackend(ExecutionBackend):
             # Use custom user_id if provided, otherwise auto-generate
             user_id = self._user_id or get_machine_id()
 
-            # Create annotation LLM with user's key
+            # Annotation LLM keeps reasoning enabled (real HED tag work).
             annotation_llm = create_openrouter_llm(
                 model=self._model,
                 api_key=self._api_key,
@@ -185,25 +185,46 @@ class LocalExecutionBackend(ExecutionBackend):
                 user_id=user_id,
             )
 
-            # Create evaluation LLM (separate model for fair benchmarking)
-            # If eval_model is specified, use it for evaluation, assessment, and feedback
-            # Otherwise, use the same model as annotation
+            # Evaluation / assessment / feedback share a model with
+            # reasoning disabled -- these are short structured tasks
+            # where extended thinking only adds latency. See #150.
             if self._eval_model:
                 evaluation_llm = create_openrouter_llm(
                     model=self._eval_model,
                     api_key=self._api_key,
                     temperature=self._temperature,
-                    provider=self._eval_provider,  # Use specified provider (e.g., Cerebras)
+                    provider=self._eval_provider,
                     user_id=user_id,
+                    disable_reasoning=True,
                 )
             else:
-                evaluation_llm = annotation_llm
+                evaluation_llm = create_openrouter_llm(
+                    model=self._model,
+                    api_key=self._api_key,
+                    temperature=self._temperature,
+                    provider=self._provider,
+                    user_id=user_id,
+                    disable_reasoning=True,
+                )
+
+            # Lightweight keyword-extraction model (#148): annotation
+            # model with reasoning off and a small token cap.
+            keyword_llm = create_openrouter_llm(
+                model=self._model,
+                api_key=self._api_key,
+                temperature=self._temperature,
+                provider=self._provider,
+                user_id=user_id,
+                max_tokens=200,
+                disable_reasoning=True,
+            )
 
             self._workflow = HedAnnotationWorkflow(
                 llm=annotation_llm,
                 evaluation_llm=evaluation_llm,
                 assessment_llm=evaluation_llm,
                 feedback_llm=evaluation_llm,
+                keyword_llm=keyword_llm,
                 schema_dir=self._schema_dir,
                 use_js_validator=False,  # Use Python validator in standalone
                 lsp_client=self._lsp_client,

--- a/src/utils/openrouter_llm.py
+++ b/src/utils/openrouter_llm.py
@@ -20,6 +20,7 @@ def create_openrouter_llm(
     provider: str | None = None,
     user_id: str | None = None,
     enable_caching: bool | None = None,
+    disable_reasoning: bool = False,
 ) -> BaseChatModel:
     """Create an OpenRouter LLM instance with optional prompt caching.
 
@@ -36,6 +37,12 @@ def create_openrouter_llm(
         user_id: User identifier for cache optimization (sticky routing)
         enable_caching: Enable Anthropic prompt caching. If None (default),
             auto-enables for Anthropic Claude models.
+        disable_reasoning: When True, disable extended thinking / reasoning
+            tokens via OpenRouter's portable ``reasoning.enabled=false``
+            flag. Useful for short structured tasks (keyword extraction,
+            judge prompts, summarization) where reasoning adds latency
+            without quality benefit. Default False preserves prior
+            behavior for callers that opt in explicitly.
 
     Returns:
         LLM instance configured for OpenRouter
@@ -61,6 +68,13 @@ def create_openrouter_llm(
     # User ID for sticky cache routing
     if user_id:
         model_kwargs["user"] = user_id
+
+    # OpenRouter normalizes this knob across providers (Anthropic
+    # "thinking", Qwen reasoning, OpenAI reasoning_effort, ...) so a
+    # single setting cleanly disables reasoning regardless of the
+    # underlying model family.
+    if disable_reasoning:
+        model_kwargs["reasoning"] = {"enabled": False}
 
     # Create base LLM with timeout to prevent hanging on slow providers
     llm = ChatLiteLLM(

--- a/src/version.py
+++ b/src/version.py
@@ -1,7 +1,7 @@
 """Version information for HEDit."""
 
-__version__ = "0.7.10a1"
-__version_info__ = (0, 7, 10, "alpha")
+__version__ = "0.7.10a2"
+__version_info__ = (0, 7, 10, "alpha2")
 
 
 def get_version() -> str:

--- a/tests/test_openrouter_llm.py
+++ b/tests/test_openrouter_llm.py
@@ -98,6 +98,40 @@ class TestCreateOpenRouterLLM:
 
         assert llm.max_tokens == 1000
 
+    def test_disable_reasoning_sets_openrouter_flag(self):
+        """`disable_reasoning=True` adds the OpenRouter portable
+        reasoning-off flag to model_kwargs. OpenRouter normalizes the
+        flag across providers (Anthropic, Qwen, OpenAI), so a single
+        setting cleanly disables thinking regardless of model family.
+        """
+        from src.utils.openrouter_llm import create_openrouter_llm
+
+        llm = create_openrouter_llm(
+            api_key="test-key",
+            enable_caching=False,
+            disable_reasoning=True,
+        )
+
+        assert llm.model_kwargs is not None
+        assert llm.model_kwargs.get("reasoning") == {"enabled": False}
+
+    def test_reasoning_not_set_by_default(self):
+        """Default (`disable_reasoning=False`) leaves model_kwargs alone.
+
+        This preserves backward-compatible behavior so callers that
+        rely on the underlying model's default reasoning posture (e.g.
+        the annotation LLM) are unaffected.
+        """
+        from src.utils.openrouter_llm import create_openrouter_llm
+
+        llm = create_openrouter_llm(
+            api_key="test-key",
+            enable_caching=False,
+        )
+
+        assert llm.model_kwargs is not None
+        assert "reasoning" not in llm.model_kwargs
+
     def test_auto_enables_caching_for_anthropic_models(self):
         """Test that caching is auto-enabled for Anthropic models."""
         from src.utils.openrouter_llm import CachingLLMWrapper, create_openrouter_llm


### PR DESCRIPTION
Closes #148, #150. Sub-issues of #147.

## Summary

After #146 landed the persistent hed-lsp client, the per-request "Initializing annotation workflow..." gap dropped from 20-60 s to ~10-12 s. Direct measurement showed the LSP call itself is **0.5 s**; the remaining time is one LLM call inside `_extract_keywords`, which in prod ran on the evaluation model (qwen3.6-35b-a3b) with extended reasoning enabled by default.

Two coupled fixes:

1. **#148** — `HedAnnotationWorkflow` takes an optional `keyword_llm`; defaults to the annotation LLM (claude-haiku-4.5 in prod) which is well-suited to a "list 5 keywords" task. `create_openrouter_workflow` and the standalone CLI build a dedicated keyword_llm with the annotation model, `max_tokens=200`, and reasoning disabled.

2. **#150** — `create_openrouter_llm` gains a `disable_reasoning` flag. When `True`, sets `model_kwargs["reasoning"] = {"enabled": False}` — OpenRouter's portable cross-provider flag that turns off extended thinking on Anthropic, Qwen, and OpenAI in one shot. Passed for evaluation_llm, assessment_llm, feedback_llm, keyword_llm. Annotation LLM keeps reasoning enabled.

## Measurement (prod container, real OpenRouter calls)

| Setup | Wall time | Output |
|---|---|---|
| claude-haiku-4.5 (default, reasoning on) | 7–9 s | thinking blocks |
| claude-haiku-4.5 with `reasoning.enabled=false`, `max_tokens=200` | **~1 s** | clean comma-separated text |
| qwen3.6-35b-a3b (reasoning on) | 1.5 s | thinking blocks |
| qwen3.6-35b-a3b with `reasoning.enabled=false` | **0.5 s** | clean text |

End-to-end expected effect: pre-annotate window goes from ~10-12 s to ~1-2 s. Evaluation / feedback / assessment calls 2x+ faster.

## Test plan

- [x] `uv run pytest -m "not integration"` -- 465 passed, 1 skipped.
- [x] `uv run pytest tests/test_openrouter_llm.py` -- 18 passed including the two new flag-passthrough tests.
- [x] `uv run pytest tests/lsp/ tests/test_validation_agent.py` -- 39 passed (real LSP, no mocks).
- [x] Local empirical test against OpenRouter confirms the timing numbers above.
- [ ] After merge + deploy: time a real /annotate request and confirm the "Initializing annotation workflow..." window dropped to ~1-2 s.

## Out of scope

- #149 (run semantic_preprocess in parallel with annotate) is the follow-up that takes the window to ~0 s perceived latency. Separate PR after this lands.