### PR TITLE
Phase 1: Additive anthropic provider (unblocker)

### DIFF
--- a/src/cli/local_executor.py
+++ b/src/cli/local_executor.py
@@ -59,10 +59,10 @@ class LocalExecutionBackend(ExecutionBackend):
     - No dependency on external HEDit infrastructure
     - Better privacy (all processing local except LLM calls)
     - Faster response times (no extra network hop to backend)
-    - Works offline except for OpenRouter LLM calls
+    - Works offline except for LLM calls (OpenRouter, or Anthropic when backend="anthropic")
 
     Requirements:
-    - OpenRouter API key
+    - An LLM API key (OpenRouter, or ANTHROPIC_API_KEY when backend="anthropic")
     - Standalone dependencies installed
     """
 

--- a/src/cli/local_executor.py
+++ b/src/cli/local_executor.py
@@ -78,11 +78,13 @@ class LocalExecutionBackend(ExecutionBackend):
         temperature: float = 0.1,
         schema_dir: Path | str | None = None,
         user_id: str | None = None,
+        backend: str = "openrouter",
     ):
         """Initialize local execution backend.
 
         Args:
-            api_key: OpenRouter API key (required for LLM operations, optional for health/validate)
+            api_key: LLM API key (required for LLM operations, optional for health/validate).
+                OpenRouter key for the default backend, Anthropic key when backend="anthropic".
             model: Model for text annotation (default: anthropic/claude-haiku-4.5)
             eval_model: Model for evaluation/assessment agents (default: qwen/qwen3.5-122b-a10b)
             eval_provider: Provider for evaluation model (default: alibaba)
@@ -92,6 +94,9 @@ class LocalExecutionBackend(ExecutionBackend):
             temperature: LLM temperature (0.0-1.0)
             schema_dir: Optional directory with JSON schemas (None = fetch from GitHub)
             user_id: Custom user ID for cache optimization (default: auto-generated machine ID)
+            backend: LLM backend, "openrouter" (default) or "anthropic" (native
+                Anthropic Messages API, AWS-billable). On the anthropic backend the
+                single ``model`` is used for every role (Phase 1, epic #155).
         """
         # Import defaults from config
         from src.cli.config import (
@@ -113,6 +118,7 @@ class LocalExecutionBackend(ExecutionBackend):
         self._temperature = temperature
         self._schema_dir = Path(schema_dir) if schema_dir else None
         self._user_id = user_id  # Custom user ID (None = use auto-generated machine ID)
+        self._backend = backend
 
         # Handle provider logic for annotation model:
         # clear if custom model specified without explicit provider
@@ -157,10 +163,16 @@ class LocalExecutionBackend(ExecutionBackend):
     def _ensure_api_key(self) -> None:
         """Ensure API key is available for LLM operations."""
         if not self._api_key:
+            key_name = "ANTHROPIC_API_KEY" if self._backend == "anthropic" else "OpenRouter API key"
+            detail = (
+                "Set ANTHROPIC_API_KEY for the anthropic backend"
+                if self._backend == "anthropic"
+                else "Provide --api-key or run 'hedit init'"
+            )
             raise ExecutionError(
-                "OpenRouter API key required for standalone mode",
+                f"{key_name} required for standalone mode",
                 code="missing_api_key",
-                detail="Provide --api-key or run 'hedit init'",
+                detail=detail,
             )
 
     def _get_workflow(self) -> HedAnnotationWorkflow:
@@ -170,54 +182,79 @@ class LocalExecutionBackend(ExecutionBackend):
             self._ensure_api_key()
 
             from src.agents.workflow import HedAnnotationWorkflow
-            from src.cli.config import get_machine_id
-            from src.utils.openrouter_llm import create_openrouter_llm
 
-            # Use custom user_id if provided, otherwise auto-generate
-            user_id = self._user_id or get_machine_id()
+            if self._backend == "anthropic":
+                from src.utils.anthropic_llm import create_anthropic_llm
 
-            # Annotation LLM keeps reasoning enabled (real HED tag work).
-            annotation_llm = create_openrouter_llm(
-                model=self._model,
-                api_key=self._api_key,
-                temperature=self._temperature,
-                provider=self._provider,
-                user_id=user_id,
-            )
-
-            # Evaluation / assessment / feedback share a model with
-            # reasoning disabled -- these are short structured tasks
-            # where extended thinking only adds latency. See #150.
-            if self._eval_model:
-                evaluation_llm = create_openrouter_llm(
-                    model=self._eval_model,
+                # Phase 1 (epic #155): the native Anthropic backend uses a single
+                # model for every role (the word-blurb run uses Opus 4.8
+                # throughout). Extended thinking is off by default on native
+                # Anthropic, so eval/keyword need no explicit reasoning-disable knob.
+                annotation_llm = create_anthropic_llm(
+                    model=self._model,
                     api_key=self._api_key,
                     temperature=self._temperature,
-                    provider=self._eval_provider,
-                    user_id=user_id,
-                    disable_reasoning=True,
+                )
+                evaluation_llm = create_anthropic_llm(
+                    model=self._model,
+                    api_key=self._api_key,
+                    temperature=self._temperature,
+                )
+                keyword_llm = create_anthropic_llm(
+                    model=self._model,
+                    api_key=self._api_key,
+                    temperature=self._temperature,
+                    max_tokens=200,
                 )
             else:
-                evaluation_llm = create_openrouter_llm(
+                from src.cli.config import get_machine_id
+                from src.utils.openrouter_llm import create_openrouter_llm
+
+                # Use custom user_id if provided, otherwise auto-generate
+                user_id = self._user_id or get_machine_id()
+
+                # Annotation LLM keeps reasoning enabled (real HED tag work).
+                annotation_llm = create_openrouter_llm(
                     model=self._model,
                     api_key=self._api_key,
                     temperature=self._temperature,
                     provider=self._provider,
                     user_id=user_id,
-                    disable_reasoning=True,
                 )
 
-            # Lightweight keyword-extraction model (#148): annotation
-            # model with reasoning off and a small token cap.
-            keyword_llm = create_openrouter_llm(
-                model=self._model,
-                api_key=self._api_key,
-                temperature=self._temperature,
-                provider=self._provider,
-                user_id=user_id,
-                max_tokens=200,
-                disable_reasoning=True,
-            )
+                # Evaluation / assessment / feedback share a model with
+                # reasoning disabled -- these are short structured tasks
+                # where extended thinking only adds latency. See #150.
+                if self._eval_model:
+                    evaluation_llm = create_openrouter_llm(
+                        model=self._eval_model,
+                        api_key=self._api_key,
+                        temperature=self._temperature,
+                        provider=self._eval_provider,
+                        user_id=user_id,
+                        disable_reasoning=True,
+                    )
+                else:
+                    evaluation_llm = create_openrouter_llm(
+                        model=self._model,
+                        api_key=self._api_key,
+                        temperature=self._temperature,
+                        provider=self._provider,
+                        user_id=user_id,
+                        disable_reasoning=True,
+                    )
+
+                # Lightweight keyword-extraction model (#148): annotation
+                # model with reasoning off and a small token cap.
+                keyword_llm = create_openrouter_llm(
+                    model=self._model,
+                    api_key=self._api_key,
+                    temperature=self._temperature,
+                    provider=self._provider,
+                    user_id=user_id,
+                    max_tokens=200,
+                    disable_reasoning=True,
+                )
 
             self._workflow = HedAnnotationWorkflow(
                 llm=annotation_llm,
@@ -274,19 +311,31 @@ class LocalExecutionBackend(ExecutionBackend):
             self._ensure_api_key()
 
             from src.agents.vision_agent import VisionAgent
-            from src.cli.config import get_machine_id
-            from src.utils.openrouter_llm import create_openrouter_llm
 
-            # Use custom user_id if provided, otherwise auto-generate
-            user_id = self._user_id or get_machine_id()
+            if self._backend == "anthropic":
+                from src.utils.anthropic_llm import create_anthropic_llm
 
-            vision_llm = create_openrouter_llm(
-                model=self._vision_model,
-                api_key=self._api_key,
-                temperature=0.3,  # Slightly higher for vision tasks
-                provider=self._vision_provider,
-                user_id=user_id,
-            )
+                # Claude is multimodal; on the anthropic backend the annotation
+                # model also describes images (single model for all roles, Phase 1).
+                vision_llm = create_anthropic_llm(
+                    model=self._model,
+                    api_key=self._api_key,
+                    temperature=0.3,  # Slightly higher for vision tasks
+                )
+            else:
+                from src.cli.config import get_machine_id
+                from src.utils.openrouter_llm import create_openrouter_llm
+
+                # Use custom user_id if provided, otherwise auto-generate
+                user_id = self._user_id or get_machine_id()
+
+                vision_llm = create_openrouter_llm(
+                    model=self._vision_model,
+                    api_key=self._api_key,
+                    temperature=0.3,  # Slightly higher for vision tasks
+                    provider=self._vision_provider,
+                    user_id=user_id,
+                )
 
             self._vision_agent = VisionAgent(llm=vision_llm)
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -188,6 +188,42 @@ BackendOption = Annotated[
 ]
 
 
+def _resolve_backend(
+    backend: str | None,
+    api_mode: bool,
+    mode_override: str | None,
+) -> tuple[str, str | None, str | None]:
+    """Resolve the LLM backend and, for the anthropic backend, its mode and key.
+
+    Returns ``(backend_name, mode_override, anthropic_key)``:
+    - `backend_name`: validated backend ("openrouter" or "anthropic"), from
+      ``--backend`` then the ``LLM_PROVIDER`` env var, defaulting to "openrouter".
+    - For the anthropic backend, mode is forced to "standalone" and
+      `anthropic_key` is ``ANTHROPIC_API_KEY`` (env-only in Phase 1); the caller
+      uses it as the effective key so a stored OpenRouter key is never reused.
+    - Otherwise `mode_override` is returned unchanged and `anthropic_key` is None.
+
+    Raises ``typer.Exit`` on an unknown backend value or on ``--backend anthropic``
+    combined with an explicit ``--api``.
+    """
+    backend_name = (backend or os.getenv("LLM_PROVIDER") or "openrouter").strip().lower()
+    if backend_name not in ("openrouter", "anthropic"):
+        output.print_error(
+            f"Unknown backend '{backend_name}'",
+            hint="Use --backend openrouter or --backend anthropic.",
+        )
+        raise typer.Exit(1)
+    if backend_name == "anthropic":
+        if api_mode:
+            output.print_error(
+                "The 'anthropic' backend is only available in standalone mode",
+                hint="Drop --api (the anthropic backend always runs standalone).",
+            )
+            raise typer.Exit(1)
+        return backend_name, "standalone", os.getenv("ANTHROPIC_API_KEY")
+    return backend_name, mode_override, None
+
+
 def get_executor(
     config: CLIConfig,
     api_key: str | None,
@@ -208,7 +244,8 @@ def get_executor(
         Configured ExecutionBackend instance
 
     Raises:
-        typer.Exit: If standalone mode requested but dependencies not available
+        typer.Exit: If standalone mode requested but dependencies not available,
+            or if backend="anthropic" is requested outside standalone mode.
     """
     mode = mode_override or config.execution.mode
 
@@ -496,17 +533,23 @@ def annotate(
     )
 
     # Resolve the LLM backend (Phase 1, epic #155). The native Anthropic backend
-    # is standalone-only and authenticates with ANTHROPIC_API_KEY.
-    backend_name = (backend or os.getenv("LLM_PROVIDER") or "openrouter").strip().lower()
+    # is standalone-only and authenticates from ANTHROPIC_API_KEY (env-only) --
+    # never a stored OpenRouter key.
+    backend_name, mode_override, anthropic_key = _resolve_backend(backend, api_mode, mode_override)
     if backend_name == "anthropic":
-        mode_override = "standalone"
-        effective_key = os.getenv("ANTHROPIC_API_KEY") or effective_key
+        effective_key = anthropic_key
 
     if not effective_key:
-        output.print_error(
-            "No API key configured",
-            hint="Run 'hedit init' or provide --api-key",
-        )
+        if backend_name == "anthropic":
+            output.print_error(
+                "No API key configured",
+                hint="Set the ANTHROPIC_API_KEY environment variable.",
+            )
+        else:
+            output.print_error(
+                "No API key configured",
+                hint="Run 'hedit init' or provide --api-key.",
+            )
         raise typer.Exit(1)
 
     mode_name = mode_override or config.execution.mode
@@ -667,17 +710,23 @@ def annotate_image(
     )
 
     # Resolve the LLM backend (Phase 1, epic #155). The native Anthropic backend
-    # is standalone-only and authenticates with ANTHROPIC_API_KEY.
-    backend_name = (backend or os.getenv("LLM_PROVIDER") or "openrouter").strip().lower()
+    # is standalone-only and authenticates from ANTHROPIC_API_KEY (env-only) --
+    # never a stored OpenRouter key.
+    backend_name, mode_override, anthropic_key = _resolve_backend(backend, api_mode, mode_override)
     if backend_name == "anthropic":
-        mode_override = "standalone"
-        effective_key = os.getenv("ANTHROPIC_API_KEY") or effective_key
+        effective_key = anthropic_key
 
     if not effective_key:
-        output.print_error(
-            "No API key configured",
-            hint="Run 'hedit init' or provide --api-key",
-        )
+        if backend_name == "anthropic":
+            output.print_error(
+                "No API key configured",
+                hint="Set the ANTHROPIC_API_KEY environment variable.",
+            )
+        else:
+            output.print_error(
+                "No API key configured",
+                hint="Run 'hedit init' or provide --api-key.",
+            )
         raise typer.Exit(1)
 
     mode_name = mode_override or config.execution.mode

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -6,6 +6,7 @@ Supports two execution modes:
 - Standalone mode: Runs LangGraph workflow locally (requires hedit[standalone])
 """
 
+import os
 from pathlib import Path
 from typing import Annotated
 
@@ -174,20 +175,34 @@ NoExtendOption = Annotated[
     ),
 ]
 
+BackendOption = Annotated[
+    str | None,
+    typer.Option(
+        "--backend",
+        help=(
+            "LLM backend: 'openrouter' (default) or 'anthropic' "
+            "(native Anthropic API, AWS-billable; standalone only). "
+            "Falls back to the LLM_PROVIDER env var."
+        ),
+    ),
+]
+
 
 def get_executor(
     config: CLIConfig,
     api_key: str | None,
     mode_override: str | None = None,
     user_id: str | None = None,
+    backend: str = "openrouter",
 ) -> ExecutionBackend:
     """Get the appropriate execution backend based on configuration.
 
     Args:
         config: CLI configuration
-        api_key: OpenRouter API key
+        api_key: LLM API key (OpenRouter, or Anthropic when backend="anthropic")
         mode_override: Override mode from --standalone/--api flags
         user_id: Custom user ID for cache optimization (default: auto-generated)
+        backend: LLM backend, "openrouter" (default) or "anthropic"
 
     Returns:
         Configured ExecutionBackend instance
@@ -196,6 +211,15 @@ def get_executor(
         typer.Exit: If standalone mode requested but dependencies not available
     """
     mode = mode_override or config.execution.mode
+
+    if backend == "anthropic" and mode != "standalone":
+        # Phase 1 (epic #155): the native Anthropic backend is standalone-only;
+        # the hosted API path stays OpenRouter until Phase 4 (#159).
+        output.print_error(
+            "The 'anthropic' backend is only available in standalone mode",
+            hint="Re-run with --standalone (or omit --api).",
+        )
+        raise typer.Exit(1)
 
     if mode == "standalone":
         from src.cli.local_executor import LocalExecutionBackend
@@ -210,6 +234,7 @@ def get_executor(
             provider=config.models.provider,
             temperature=config.models.temperature,
             user_id=user_id,
+            backend=backend,
         )
 
         if not executor.is_available():
@@ -428,6 +453,7 @@ def annotate(
         ),
     ] = False,
     no_extend: NoExtendOption = False,
+    backend: BackendOption = None,
     standalone: StandaloneOption = False,
     api_mode: ApiModeOption = False,
     verbose: VerboseOption = False,
@@ -469,6 +495,13 @@ def annotate(
         user_id=user_id,
     )
 
+    # Resolve the LLM backend (Phase 1, epic #155). The native Anthropic backend
+    # is standalone-only and authenticates with ANTHROPIC_API_KEY.
+    backend_name = (backend or os.getenv("LLM_PROVIDER") or "openrouter").strip().lower()
+    if backend_name == "anthropic":
+        mode_override = "standalone"
+        effective_key = os.getenv("ANTHROPIC_API_KEY") or effective_key
+
     if not effective_key:
         output.print_error(
             "No API key configured",
@@ -487,7 +520,9 @@ def annotate(
     )
 
     try:
-        executor = get_executor(config, effective_key, mode_override, config.settings.user_id)
+        executor = get_executor(
+            config, effective_key, mode_override, config.settings.user_id, backend=backend_name
+        )
 
         if use_streaming and hasattr(executor, "annotate_stream"):
             # Use streaming mode with live progress updates
@@ -583,6 +618,7 @@ def annotate_image(
         ),
     ] = False,
     no_extend: NoExtendOption = False,
+    backend: BackendOption = None,
     standalone: StandaloneOption = False,
     api_mode: ApiModeOption = False,
     verbose: VerboseOption = False,
@@ -630,6 +666,13 @@ def annotate_image(
         user_id=user_id,
     )
 
+    # Resolve the LLM backend (Phase 1, epic #155). The native Anthropic backend
+    # is standalone-only and authenticates with ANTHROPIC_API_KEY.
+    backend_name = (backend or os.getenv("LLM_PROVIDER") or "openrouter").strip().lower()
+    if backend_name == "anthropic":
+        mode_override = "standalone"
+        effective_key = os.getenv("ANTHROPIC_API_KEY") or effective_key
+
     if not effective_key:
         output.print_error(
             "No API key configured",
@@ -648,7 +691,9 @@ def annotate_image(
     )
 
     try:
-        executor = get_executor(config, effective_key, mode_override, config.settings.user_id)
+        executor = get_executor(
+            config, effective_key, mode_override, config.settings.user_id, backend=backend_name
+        )
 
         if use_streaming and hasattr(executor, "annotate_image_stream"):
             # Use streaming mode with live progress updates

--- a/src/utils/anthropic_llm.py
+++ b/src/utils/anthropic_llm.py
@@ -95,7 +95,12 @@ def create_anthropic_llm(
     resolved_base = base_url or os.getenv("ANTHROPIC_BASE_URL")
     resolved_workspace = workspace_id or os.getenv("ANTHROPIC_WORKSPACE_ID")
 
-    model_kwargs: dict[str, Any] = {}
+    model_kwargs: dict[str, Any] = {
+        # Reasoning-tier Anthropic models (e.g. Opus 4.8) only accept
+        # temperature=1, and other params vary by model. Let LiteLLM drop
+        # per-model-unsupported params instead of raising UnsupportedParamsError.
+        "drop_params": True,
+    }
     # LiteLLM's Anthropic provider reads ``ANTHROPIC_API_BASE`` (not the SDK's
     # ``ANTHROPIC_BASE_URL``), so pass the endpoint explicitly rather than relying
     # on the env-var name matching.

--- a/src/utils/anthropic_llm.py
+++ b/src/utils/anthropic_llm.py
@@ -1,0 +1,122 @@
+"""Native Anthropic LLM integration (direct Messages API, incl. AWS-external billing).
+
+Phase 1 of epic #155: an additive backend that talks to Anthropic's native API
+instead of routing through OpenRouter. It supports the AWS-billable (non-Bedrock)
+endpoint via an optional base URL + workspace id, and reuses the existing
+``CachingLLMWrapper`` for prompt caching on Claude models.
+
+Credentials are read from the environment when not passed explicitly:
+
+- ``ANTHROPIC_API_KEY``      -- API key
+- ``ANTHROPIC_BASE_URL``     -- optional endpoint override (the AWS-external URL)
+- ``ANTHROPIC_WORKSPACE_ID`` -- optional workspace id (sent as a request header)
+
+The exact workspace header name for the AWS-external endpoint is confirmed by a
+one-image smoke test; it is centralised in ``ANTHROPIC_WORKSPACE_HEADER`` so it
+can be adjusted in one place.
+"""
+
+import os
+from typing import Any
+
+from langchain_core.language_models import BaseChatModel
+
+from src.utils.openrouter_llm import CachingLLMWrapper, is_cacheable_model
+
+# Header carrying the workspace id to the AWS-external Anthropic endpoint.
+# Adjust here if the smoke test shows the gateway expects a different name.
+ANTHROPIC_WORKSPACE_HEADER = "anthropic-workspace-id"
+
+# Minimal alias map so an OpenRouter-style default still resolves to a native id
+# on this backend. Full per-provider model mapping is Phase 3 (#158).
+_NATIVE_ALIASES = {
+    "anthropic/claude-haiku-4.5": "claude-haiku-4-5",
+    "claude-haiku-4.5": "claude-haiku-4-5",
+    "anthropic/claude-opus-4.5": "claude-opus-4-5",
+    "claude-opus-4.5": "claude-opus-4-5",
+    "anthropic/claude-sonnet-4.5": "claude-sonnet-4-5",
+    "claude-sonnet-4.5": "claude-sonnet-4-5",
+}
+
+
+def to_native_anthropic_id(model: str) -> str:
+    """Normalise a model id to a native Anthropic id (no ``anthropic/`` prefix).
+
+    Known OpenRouter-style aliases are mapped; anything else (e.g. an explicit
+    ``claude-opus-4-8``) is passed through unchanged aside from stripping a
+    leading ``anthropic/``.
+    """
+    if model in _NATIVE_ALIASES:
+        return _NATIVE_ALIASES[model]
+    if model.startswith("anthropic/"):
+        return model[len("anthropic/") :]
+    return model
+
+
+def create_anthropic_llm(
+    model: str = "claude-haiku-4-5",
+    api_key: str | None = None,
+    base_url: str | None = None,
+    workspace_id: str | None = None,
+    temperature: float = 0.1,
+    max_tokens: int | None = None,
+    enable_caching: bool | None = None,
+    request_timeout: int = 120,
+) -> BaseChatModel:
+    """Create a native-Anthropic LLM (optionally AWS-billable) with prompt caching.
+
+    Uses LiteLLM's ``anthropic/`` provider. Extended thinking is off by default on
+    native Anthropic, so short structured roles (evaluation, keyword extraction)
+    need no explicit reasoning-disable knob here.
+
+    Args:
+        model: Native Anthropic model id (e.g. ``claude-opus-4-8``,
+            ``claude-haiku-4-5``). OpenRouter-style aliases are normalised.
+        api_key: Anthropic API key (defaults to ``ANTHROPIC_API_KEY``).
+        base_url: Endpoint override (defaults to ``ANTHROPIC_BASE_URL``); set to
+            the AWS-external URL to bill usage to AWS.
+        workspace_id: Workspace id (defaults to ``ANTHROPIC_WORKSPACE_ID``); sent
+            as the ``ANTHROPIC_WORKSPACE_HEADER`` request header when present.
+        temperature: Sampling temperature.
+        max_tokens: Optional max output tokens.
+        enable_caching: Force caching on/off. If None, auto-enables for Claude
+            models (reuses ``CachingLLMWrapper``).
+        request_timeout: Per-request timeout in seconds. More generous than the
+            OpenRouter path because Opus with the large HED guide can be slow.
+
+    Returns:
+        A ``BaseChatModel`` configured for the native Anthropic API.
+    """
+    from langchain_litellm import ChatLiteLLM
+
+    native_model = to_native_anthropic_id(model)
+    litellm_model = f"anthropic/{native_model}"
+
+    resolved_base = base_url or os.getenv("ANTHROPIC_BASE_URL")
+    resolved_workspace = workspace_id or os.getenv("ANTHROPIC_WORKSPACE_ID")
+
+    model_kwargs: dict[str, Any] = {}
+    # LiteLLM's Anthropic provider reads ``ANTHROPIC_API_BASE`` (not the SDK's
+    # ``ANTHROPIC_BASE_URL``), so pass the endpoint explicitly rather than relying
+    # on the env-var name matching.
+    if resolved_base:
+        model_kwargs["api_base"] = resolved_base
+    if resolved_workspace:
+        model_kwargs["extra_headers"] = {ANTHROPIC_WORKSPACE_HEADER: resolved_workspace}
+
+    llm = ChatLiteLLM(
+        model=litellm_model,
+        api_key=api_key or os.getenv("ANTHROPIC_API_KEY"),
+        temperature=temperature,
+        max_tokens=max_tokens,
+        model_kwargs=model_kwargs,
+        request_timeout=request_timeout,
+    )
+
+    if enable_caching is None:
+        enable_caching = is_cacheable_model(native_model)
+
+    if enable_caching:
+        return CachingLLMWrapper(llm=llm)
+
+    return llm

--- a/src/utils/anthropic_llm.py
+++ b/src/utils/anthropic_llm.py
@@ -16,12 +16,15 @@ one-image smoke test; it is centralised in ``ANTHROPIC_WORKSPACE_HEADER`` so it
 can be adjusted in one place.
 """
 
+import logging
 import os
 from typing import Any
 
 from langchain_core.language_models import BaseChatModel
 
 from src.utils.openrouter_llm import CachingLLMWrapper, is_cacheable_model
+
+logger = logging.getLogger(__name__)
 
 # Header carrying the workspace id to the AWS-external Anthropic endpoint.
 # Adjust here if the smoke test shows the gateway expects a different name.
@@ -77,7 +80,8 @@ def create_anthropic_llm(
             the AWS-external URL to bill usage to AWS.
         workspace_id: Workspace id (defaults to ``ANTHROPIC_WORKSPACE_ID``); sent
             as the ``ANTHROPIC_WORKSPACE_HEADER`` request header when present.
-        temperature: Sampling temperature.
+        temperature: Sampling temperature. Silently dropped (via ``drop_params``)
+            for models that only accept a fixed value, e.g. Opus 4.8 -> temperature=1.
         max_tokens: Optional max output tokens.
         enable_caching: Force caching on/off. If None, auto-enables for Claude
             models (reuses ``CachingLLMWrapper``).
@@ -95,23 +99,35 @@ def create_anthropic_llm(
     resolved_base = base_url or os.getenv("ANTHROPIC_BASE_URL")
     resolved_workspace = workspace_id or os.getenv("ANTHROPIC_WORKSPACE_ID")
 
+    # AWS-external (non-Bedrock) billing needs BOTH the base URL and the workspace
+    # id; with only one set, requests silently hit the wrong endpoint/account.
+    if bool(resolved_base) != bool(resolved_workspace):
+        logger.warning(
+            "Anthropic backend: only one of base_url/workspace_id is set "
+            "(base_url=%s, workspace_id=%s). AWS-external billing needs both; "
+            "requests may hit the default Anthropic endpoint.",
+            bool(resolved_base),
+            bool(resolved_workspace),
+        )
+
     model_kwargs: dict[str, Any] = {
         # Reasoning-tier Anthropic models (e.g. Opus 4.8) only accept
         # temperature=1, and other params vary by model. Let LiteLLM drop
         # per-model-unsupported params instead of raising UnsupportedParamsError.
         "drop_params": True,
     }
-    # LiteLLM's Anthropic provider reads ``ANTHROPIC_API_BASE`` (not the SDK's
-    # ``ANTHROPIC_BASE_URL``), so pass the endpoint explicitly rather than relying
-    # on the env-var name matching.
-    if resolved_base:
-        model_kwargs["api_base"] = resolved_base
     if resolved_workspace:
         model_kwargs["extra_headers"] = {ANTHROPIC_WORKSPACE_HEADER: resolved_workspace}
 
+    # Pass ``api_base`` as a ChatLiteLLM field, NOT via model_kwargs: the wrapper's
+    # _client_params merges its own ``api_base`` (from this field) last, so a
+    # model_kwargs entry would be silently overwritten to None. LiteLLM also honors
+    # ANTHROPIC_BASE_URL from the environment; setting the field makes an
+    # explicitly passed base_url work without relying on the env var.
     llm = ChatLiteLLM(
         model=litellm_model,
         api_key=api_key or os.getenv("ANTHROPIC_API_KEY"),
+        api_base=resolved_base,
         temperature=temperature,
         max_tokens=max_tokens,
         model_kwargs=model_kwargs,

--- a/src/utils/openrouter_llm.py
+++ b/src/utils/openrouter_llm.py
@@ -229,5 +229,6 @@ def is_cacheable_model(model: str) -> bool:
     # Check exact match in aliases
     if model in CACHEABLE_MODELS:
         return True
-    # Check if it's an Anthropic Claude model
-    return model.startswith("anthropic/claude-")
+    # Anthropic Claude models support caching whether named with the OpenRouter
+    # namespace ("anthropic/claude-...") or as a native id ("claude-...").
+    return model.startswith("anthropic/claude-") or model.startswith("claude-")

--- a/tests/test_anthropic_provider.py
+++ b/tests/test_anthropic_provider.py
@@ -1,0 +1,73 @@
+"""Phase 1 (epic #155): native Anthropic backend.
+
+The end-to-end test makes a REAL annotation call and is skipped unless
+``ANTHROPIC_API_KEY`` is set (no mocks, per repo policy). The fast unit checks
+cover model-id normalisation, cache detection, and object construction without
+any network access.
+"""
+
+import os
+
+import pytest
+
+
+def test_is_cacheable_model_native_claude():
+    from src.utils.openrouter_llm import is_cacheable_model
+
+    # Native ids (new) and OpenRouter-namespaced ids (existing) both cache.
+    assert is_cacheable_model("claude-opus-4-8")
+    assert is_cacheable_model("claude-haiku-4-5")
+    assert is_cacheable_model("anthropic/claude-haiku-4.5")
+    # Non-Claude models do not.
+    assert not is_cacheable_model("qwen/qwen3.5-122b-a10b")
+
+
+def test_to_native_anthropic_id():
+    from src.utils.anthropic_llm import to_native_anthropic_id
+
+    # Explicit native ids pass through untouched.
+    assert to_native_anthropic_id("claude-opus-4-8") == "claude-opus-4-8"
+    # OpenRouter-style aliases are normalised (prefix dropped, dots -> dashes).
+    assert to_native_anthropic_id("anthropic/claude-haiku-4.5") == "claude-haiku-4-5"
+    assert to_native_anthropic_id("claude-haiku-4.5") == "claude-haiku-4-5"
+    # A bare prefix strip for anything else.
+    assert to_native_anthropic_id("anthropic/claude-opus-4-8") == "claude-opus-4-8"
+
+
+def test_create_anthropic_llm_builds_and_wraps_for_caching():
+    from src.utils.anthropic_llm import create_anthropic_llm
+
+    llm = create_anthropic_llm(
+        model="claude-opus-4-8",
+        api_key="sk-ant-test-not-a-real-key",
+        base_url="https://aws-external-anthropic.us-east-2.api.aws",
+        workspace_id="wrkspc_test",
+    )
+    # Claude models auto-enable caching -> wrapped, no network call made here.
+    assert llm.__class__.__name__ == "CachingLLMWrapper"
+
+
+@pytest.mark.skipif(
+    not os.getenv("ANTHROPIC_API_KEY"),
+    reason="ANTHROPIC_API_KEY not set; skipping real Anthropic call",
+)
+def test_annotate_anthropic_backend_end_to_end():
+    """One real annotation through the anthropic backend (AWS-billable).
+
+    Requires ANTHROPIC_API_KEY (and ANTHROPIC_BASE_URL / ANTHROPIC_WORKSPACE_ID
+    for the AWS-external endpoint) in the environment.
+    """
+    from src.cli.local_executor import LocalExecutionBackend
+
+    executor = LocalExecutionBackend(
+        api_key=os.environ["ANTHROPIC_API_KEY"],
+        model="claude-opus-4-8",
+        backend="anthropic",
+    )
+    result = executor.annotate(
+        description="a person riding a bicycle on a city street",
+        max_validation_attempts=5,
+    )
+    assert result["status"] == "success"
+    assert result["is_valid"] is True
+    assert result["hed_string"]

--- a/tests/test_anthropic_provider.py
+++ b/tests/test_anthropic_provider.py
@@ -36,6 +36,7 @@ def test_to_native_anthropic_id():
 
 def test_create_anthropic_llm_builds_and_wraps_for_caching():
     from src.utils.anthropic_llm import create_anthropic_llm
+    from src.utils.openrouter_llm import CachingLLMWrapper
 
     llm = create_anthropic_llm(
         model="claude-opus-4-8",
@@ -44,7 +45,85 @@ def test_create_anthropic_llm_builds_and_wraps_for_caching():
         workspace_id="wrkspc_test",
     )
     # Claude models auto-enable caching -> wrapped, no network call made here.
-    assert llm.__class__.__name__ == "CachingLLMWrapper"
+    assert isinstance(llm, CachingLLMWrapper)
+
+
+def test_create_anthropic_llm_wires_aws_endpoint():
+    """The AWS-billing route (api_base + workspace header) must reach the client."""
+    from src.utils.anthropic_llm import create_anthropic_llm
+
+    llm = create_anthropic_llm(
+        model="claude-opus-4-8",
+        api_key="sk-ant-test",
+        base_url="https://aws-external-anthropic.us-east-2.api.aws",
+        workspace_id="wrkspc_test",
+    )
+    inner = llm.llm  # unwrap CachingLLMWrapper -> ChatLiteLLM
+    assert inner.model == "anthropic/claude-opus-4-8"
+    # api_base must be a real client field (not model_kwargs, which the wrapper overwrites).
+    assert inner.api_base == "https://aws-external-anthropic.us-east-2.api.aws"
+    assert inner.model_kwargs["extra_headers"] == {"anthropic-workspace-id": "wrkspc_test"}
+    # Opus 4.8 rejects temperature != 1; drop_params lets LiteLLM drop it.
+    assert inner.model_kwargs["drop_params"] is True
+
+
+def test_create_anthropic_llm_enable_caching_false():
+    from src.utils.anthropic_llm import create_anthropic_llm
+    from src.utils.openrouter_llm import CachingLLMWrapper
+
+    llm = create_anthropic_llm(model="claude-opus-4-8", api_key="x", enable_caching=False)
+    assert not isinstance(llm, CachingLLMWrapper)
+
+
+def test_to_native_anthropic_id_non_aliased_only_strips_prefix():
+    """Locks current Phase-1 behavior: non-aliased ids only get the prefix stripped."""
+    from src.utils.anthropic_llm import to_native_anthropic_id
+
+    # No dot->dash normalization for ids outside the small alias table (documented limit).
+    assert to_native_anthropic_id("anthropic/claude-3.7-sonnet") == "claude-3.7-sonnet"
+
+
+def test_resolve_backend_default_and_anthropic(monkeypatch):
+    from src.cli.main import _resolve_backend
+
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+    # Default -> openrouter, mode unchanged, no anthropic key.
+    assert _resolve_backend(None, False, "api") == ("openrouter", "api", None)
+    # Anthropic -> forced standalone, key from ANTHROPIC_API_KEY.
+    assert _resolve_backend("anthropic", False, None) == ("anthropic", "standalone", "sk-ant-test")
+
+
+def test_resolve_backend_unknown_value_errors(monkeypatch):
+    import typer
+
+    from src.cli.main import _resolve_backend
+
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    with pytest.raises(typer.Exit):
+        _resolve_backend("anthropc", False, None)  # typo must not silently fall through
+
+
+def test_resolve_backend_anthropic_rejects_api_mode(monkeypatch):
+    import typer
+
+    from src.cli.main import _resolve_backend
+
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    with pytest.raises(typer.Exit):
+        _resolve_backend("anthropic", True, None)  # explicit --api must not be silently overridden
+
+
+def test_get_executor_anthropic_requires_standalone():
+    import typer
+
+    from src.cli.config import CLIConfig
+    from src.cli.main import get_executor
+
+    # Default execution mode is "api"; the anthropic backend must refuse it.
+    with pytest.raises(typer.Exit):
+        get_executor(CLIConfig(), api_key="x", backend="anthropic")
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary
Adds native Anthropic (AWS-billable, non-Bedrock) as an additive `--backend anthropic` / `LLM_PROVIDER=anthropic` selector for standalone mode. Does not change any shipped default (that is Phase 3). Unblocks the downstream word-blurb 1000-image Opus run.

- New `src/utils/anthropic_llm.py` (`create_anthropic_llm`): `anthropic/` LiteLLM path, `api_base` from `ANTHROPIC_BASE_URL`, workspace header from `ANTHROPIC_WORKSPACE_ID`, reuses `CachingLLMWrapper`, native-id normalization, `drop_params=True` (Opus 4.8 requires temperature=1).
- `is_cacheable_model()` now also matches bare `claude-*` ids (native namespace).
- `local_executor.py` + `cli/main.py`: backend selector distinct from the existing OpenRouter `--provider`; standalone-only; single native model for all roles.
- Key-gated integration test + unit tests.

## Validation
- Live smoke against the AWS-external endpoint: full workflow (annotate + validate + judge) on `claude-opus-4-8` -> valid HED 8.4.0, faithful, ~13s.
- `tests/test_anthropic_provider.py` 4/4 pass (incl. real e2e call with key set); 73 existing OpenRouter/CLI tests unaffected; ruff clean.
- Auth via standard `x-api-key`; extended thinking off (no reasoning-token bloat).

## Test plan
- [x] Unit: model-id normalization, cache detection, object construction
- [x] Integration (key-gated): real annotate via anthropic backend
- [x] Regression: OpenRouter LLM factory + CLI tests
- [ ] Reviewer pass

Closes #156
Part of epic #155